### PR TITLE
Add types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "React JS component for Twitter's conversion tracking.",
   "main": "src/index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for react-twitter-conversion-tracker 1.0
+// Project: https://github.com/evankyle/react-twitter-conversion-tracker
+// Definitions by: Coteh <https://github.com/Coteh>
+// Definitions: https://github.com/evankyle/react-twitter-conversion-tracker
+
+export function init(convId: string): void;
+
+export function pageView(): void;

--- a/types/react-twitter-conversion-tracker-tests.ts
+++ b/types/react-twitter-conversion-tracker-tests.ts
@@ -1,4 +1,4 @@
-import TwitterConvTrkr from './index';
+import TwitterConvTrkr = require('./index');
 
 TwitterConvTrkr.init('nuqtg');
 

--- a/types/react-twitter-conversion-tracker-tests.ts
+++ b/types/react-twitter-conversion-tracker-tests.ts
@@ -1,0 +1,5 @@
+import TwitterConvTrkr from './index';
+
+TwitterConvTrkr.init('nuqtg');
+
+TwitterConvTrkr.pageView();

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -14,8 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "allowSyntheticDefaultImports": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "allowSyntheticDefaultImports": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-twitter-conversion-tracker-tests.ts"
+    ]
+}


### PR DESCRIPTION
Add types so that this project can be used in TypeScript projects without having to add `@ts-ignore` to ignore the error for missing module types.